### PR TITLE
Fix invalid bucket calculation for operations

### DIFF
--- a/pkg/workload/core.go
+++ b/pkg/workload/core.go
@@ -26,8 +26,6 @@ import (
 	"time"
 
 	"cloud.google.com/go/spanner"
-	"github.com/olekukonko/tablewriter"
-	"github.com/rcrowley/go-metrics"
 	"github.com/cloudspannerecosystem/gcsb/pkg/config"
 	"github.com/cloudspannerecosystem/gcsb/pkg/generator"
 	"github.com/cloudspannerecosystem/gcsb/pkg/generator/data"
@@ -36,6 +34,8 @@ import (
 	"github.com/cloudspannerecosystem/gcsb/pkg/generator/selector"
 	"github.com/cloudspannerecosystem/gcsb/pkg/schema"
 	"github.com/cloudspannerecosystem/gcsb/pkg/workload/pool"
+	"github.com/olekukonko/tablewriter"
+	"github.com/rcrowley/go-metrics"
 )
 
 var (
@@ -489,9 +489,7 @@ func (c *CoreWorkload) bucketOps(n int, k int) []int {
 		if o > 0 {
 			r[i] = e + 1
 			o--
-		}
-
-		if o == 0 {
+		} else {
 			r[i] = e
 		}
 	}

--- a/pkg/workload/core_test.go
+++ b/pkg/workload/core_test.go
@@ -1,0 +1,51 @@
+package workload
+
+import "testing"
+
+func TestBucketOps(t *testing.T) {
+	tests := []struct {
+		desc       string
+		operations int
+		buckets    int
+		want       []int
+	}{
+		{
+			desc:       "operations are evenly distributed",
+			operations: 10,
+			buckets:    5,
+			want:       []int{2, 2, 2, 2, 2},
+		},
+		{
+			desc:       "operations are distributed unequally",
+			operations: 10,
+			buckets:    4,
+			want:       []int{3, 3, 2, 2},
+		},
+		{
+			desc:       "some buckets have empty operations",
+			operations: 5,
+			buckets:    10,
+			want:       []int{1, 1, 1, 1, 1, 0, 0, 0, 0, 0},
+		},
+	}
+	for _, test := range tests {
+		t.Run(test.desc, func(t *testing.T) {
+			got := (&CoreWorkload{}).bucketOps(test.operations, test.buckets)
+			if !isSameSlice(got, test.want) {
+				t.Errorf("bucketOps(%v, %v) = %v, but want = %v", test.operations, test.buckets, got, test.want)
+			}
+		})
+	}
+}
+
+func isSameSlice(a, b []int) bool {
+	if len(a) != len(b) {
+		return false
+	}
+	for i := 0; i < len(a); i++ {
+		if a[i] != b[i] {
+			return false
+		}
+	}
+	return true
+}


### PR DESCRIPTION
## Description
Fixed a bug that caused invalid bucket calculation for operations, specifically when the operations are not evenly distributed to the buckets.

For example, if a user specify `--operations=5 --threads=10`, current implementation produced `[1, 1, 1, 1, 0, 0, 0, 0, 0, 0]` buckets. Note that total operations are 4 and 1 operation was dropped from the buckets.

This caused missing database rows when using `load` operation (i.e. user expects 5 rows inserted, but actually only 4 rows inserted).

## Test result

Before fix:
```
=== RUN   TestBucketOps
=== RUN   TestBucketOps/operations_are_evenly_distributed
=== RUN   TestBucketOps/operations_are_distributed_unequally
    core_test.go:35: bucketOps(10, 4) = [3 2 2 2], but want = [3 3 2 2]
=== RUN   TestBucketOps/some_buckets_have_empty_operations
    core_test.go:35: bucketOps(5, 10) = [1 1 1 1 0 0 0 0 0 0], but want = [1 1 1 1 1 0 0 0 0 0]
--- FAIL: TestBucketOps (0.00s)
    --- PASS: TestBucketOps/operations_are_evenly_distributed (0.00s)
    --- FAIL: TestBucketOps/operations_are_distributed_unequally (0.00s)
    --- FAIL: TestBucketOps/some_buckets_have_empty_operations (0.00s)
FAIL
FAIL	github.com/cloudspannerecosystem/gcsb/pkg/workload	0.203s
FAIL
```

After fix:
```
=== RUN   TestBucketOps
=== RUN   TestBucketOps/operations_are_evenly_distributed
=== RUN   TestBucketOps/operations_are_distributed_unequally
=== RUN   TestBucketOps/some_buckets_have_empty_operations
--- PASS: TestBucketOps (0.00s)
    --- PASS: TestBucketOps/operations_are_evenly_distributed (0.00s)
    --- PASS: TestBucketOps/operations_are_distributed_unequally (0.00s)
    --- PASS: TestBucketOps/some_buckets_have_empty_operations (0.00s)
PASS
ok  	github.com/cloudspannerecosystem/gcsb/pkg/workload	0.928s
```