### PR TITLE
UUID v4

### DIFF
--- a/README.md
+++ b/README.md
@@ -194,6 +194,14 @@ Please note, at present, the yaml conifguration file is the only way to specify 
 
 For in depth information on the various configuration values, please read the comments in [example_gcsb.yaml](example_gcsb.yaml)
 
+### Supported generator type
+
+The tool supports the following generator type in the configuration.
+
+| type | description |
+|------|-------------|
+| `UUID_V4` | Generates UUID v4 value. Supported column types are `STRING` and `BYTES`. Note that UUID is automatically inferred for `STRING(36)` column without a configuration. |
+
 ## Roadmap
 
 ### Not Supported (yet)

--- a/example_gcsb.yaml
+++ b/example_gcsb.yaml
@@ -13,7 +13,7 @@
 # limitations under the License.
 
 # GCP Project ID
-project:  YOUR_PROJECT_ID
+project: YOUR_PROJECT_ID
 
 # Spanner Instance ID
 instance: YOUR_SPANNER_INSTANCE_ID
@@ -51,7 +51,7 @@ pool:
 # NOT CURRENTLY SUPPORTED
 max_execution_time: 1h
 
-operations: 
+operations:
   # Total number of operations
   total: 5000
   # Read operation weight
@@ -77,6 +77,9 @@ operations:
 tables:
   - name: SingleSingers
     columns:
+      - name: SingerId
+        generator:
+          type: UUID_V4
       - name: FirstName
         generator:
           length: 10

--- a/go.mod
+++ b/go.mod
@@ -12,6 +12,7 @@ require (
 	github.com/envoyproxy/go-control-plane v0.10.1 // indirect
 	github.com/envoyproxy/protoc-gen-validate v0.6.2 // indirect
 	github.com/golang/groupcache v0.0.0-20210331224755-41bb18bfe9da // indirect
+	github.com/google/uuid v1.3.0
 	github.com/hashicorp/go-multierror v1.0.0
 	github.com/mattn/go-runewidth v0.0.13 // indirect
 	github.com/olekukonko/tablewriter v0.0.5

--- a/go.sum
+++ b/go.sum
@@ -181,6 +181,8 @@ github.com/google/pprof v0.0.0-20210720184732-4bb14d4b1be1/go.mod h1:kpwsk12EmLe
 github.com/google/renameio v0.1.0/go.mod h1:KWCgfxg9yswjAJkECMjeO8J8rahYeXnNhOm40UhjYkI=
 github.com/google/uuid v1.1.2 h1:EVhdT+1Kseyi1/pUmXKaFxYsDNy9RQYkMWRH68J/W7Y=
 github.com/google/uuid v1.1.2/go.mod h1:TIyPZe4MgqvfeYDBFedMoGGpEw/LqOeaOT+nhxU+yHo=
+github.com/google/uuid v1.3.0 h1:t6JiXgmwXMjEs8VusXIJk2BXHsn+wx8BZdTaoZ5fu7I=
+github.com/google/uuid v1.3.0/go.mod h1:TIyPZe4MgqvfeYDBFedMoGGpEw/LqOeaOT+nhxU+yHo=
 github.com/googleapis/gax-go/v2 v2.0.4/go.mod h1:0Wqv26UfaUD9n4G6kQubkQ+KchISgw+vpHVxEJEs9eg=
 github.com/googleapis/gax-go/v2 v2.0.5/go.mod h1:DWXyrwAJ9X0FpwwEdw+IPEYBICEFu5mhpdKc/us6bOk=
 github.com/googleapis/gax-go/v2 v2.1.0/go.mod h1:Q3nei7sK6ybPYH7twZdmQpAd1MKb7pfu6SK+H1/DsU0=

--- a/pkg/generator/data/uuid_v4.go
+++ b/pkg/generator/data/uuid_v4.go
@@ -1,0 +1,86 @@
+// Copyright 2022 Google LLC
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//      http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package data
+
+import (
+	"fmt"
+	"strings"
+
+	"cloud.google.com/go/spanner/spansql"
+	"github.com/google/uuid"
+)
+
+const (
+	uuidV4LenString                 = 36
+	uuidV4LenStringWithoutSeparator = 32
+	uuidV4LenBytes                  = 16
+)
+
+// Assert that UUIDV4Generator implements Generator
+var _ Generator = (*UUIDV4Generator)(nil)
+
+// UUIDV4Generator is a generator for UUID v4.
+type UUIDV4Generator struct {
+	colType   spansql.TypeBase
+	colLength int64
+}
+
+// NewUUIDV4Generator returns a generator for UUID v4.
+func NewUUIDV4Generator(colType spansql.TypeBase, colLength int64) (Generator, error) {
+	// Validate column.
+	switch colType {
+	case spansql.String:
+		if colLength != uuidV4LenString && colLength != uuidV4LenStringWithoutSeparator {
+			return nil, fmt.Errorf("invalid column length for string UUID: %d", colLength)
+		}
+	case spansql.Bytes:
+		if colLength != uuidV4LenBytes {
+			return nil, fmt.Errorf("invalid column length for string UUID: %d", colLength)
+		}
+	default:
+		return nil, fmt.Errorf("invalid column type for UUID: %v", colType.SQL())
+	}
+
+	return &UUIDV4Generator{
+		colType:   colType,
+		colLength: colLength,
+	}, nil
+}
+
+// Next returns the random UUID v4 value.
+func (g *UUIDV4Generator) Next() interface{} {
+	id, err := uuid.NewRandom()
+	if err != nil {
+		panic(fmt.Sprintf("unexpected UUID v4 generation error: %v", err))
+	}
+
+	if g.colType == spansql.Bytes {
+		// NOTE: uuid.MarshalBinary always returns nil error.
+		b, _ := id.MarshalBinary()
+		return b
+	}
+
+	if g.colLength == uuidV4LenStringWithoutSeparator {
+		// Returns UUID without separators "-".
+		return strings.Join(strings.Split(id.String(), "-"), "")
+	}
+
+	return id.String()
+}
+
+// Type returns the type for UUID v4 generator.
+func (g *UUIDV4Generator) Type() spansql.TypeBase {
+	return g.colType
+}

--- a/pkg/generator/data/uuid_v4.go
+++ b/pkg/generator/data/uuid_v4.go
@@ -42,12 +42,12 @@ func NewUUIDV4Generator(colType spansql.TypeBase, colLength int64) (Generator, e
 	// Validate column.
 	switch colType {
 	case spansql.String:
-		if colLength != uuidV4LenString && colLength != uuidV4LenStringWithoutSeparator {
+		if colLength < uuidV4LenStringWithoutSeparator {
 			return nil, fmt.Errorf("invalid column length for string UUID: %d", colLength)
 		}
 	case spansql.Bytes:
-		if colLength != uuidV4LenBytes {
-			return nil, fmt.Errorf("invalid column length for string UUID: %d", colLength)
+		if colLength < uuidV4LenBytes {
+			return nil, fmt.Errorf("invalid column length for bytes UUID: %d", colLength)
 		}
 	default:
 		return nil, fmt.Errorf("invalid column type for UUID: %v", colType.SQL())
@@ -72,7 +72,7 @@ func (g *UUIDV4Generator) Next() interface{} {
 		return b
 	}
 
-	if g.colLength == uuidV4LenStringWithoutSeparator {
+	if g.colLength >= uuidV4LenStringWithoutSeparator && g.colLength < uuidV4LenString {
 		// Returns UUID without separators "-".
 		return strings.Join(strings.Split(id.String(), "-"), "")
 	}

--- a/pkg/generator/data/uuid_v4_test.go
+++ b/pkg/generator/data/uuid_v4_test.go
@@ -41,9 +41,21 @@ func TestNewUUIDV4Generator(t *testing.T) {
 			wantErr: false,
 		},
 		{
+			desc:    "STRING(40) should be valid",
+			colType: spansql.String,
+			colLen:  40,
+			wantErr: false,
+		},
+		{
 			desc:    "BYTES(16) should be valid",
 			colType: spansql.Bytes,
 			colLen:  16,
+			wantErr: false,
+		},
+		{
+			desc:    "BYTES(32) should be valid",
+			colType: spansql.Bytes,
+			colLen:  32,
 			wantErr: false,
 		},
 		{
@@ -87,6 +99,15 @@ func TestUUIDV4GeneratorNext(t *testing.T) {
 			wantLen:  36,
 		},
 		{
+			desc: "UUID for STRING(40)",
+			generator: &UUIDV4Generator{
+				colType:   spansql.String,
+				colLength: 40,
+			},
+			wantType: "string",
+			wantLen:  36,
+		},
+		{
 			desc: "UUID for STRING(32)",
 			generator: &UUIDV4Generator{
 				colType:   spansql.String,
@@ -100,6 +121,15 @@ func TestUUIDV4GeneratorNext(t *testing.T) {
 			generator: &UUIDV4Generator{
 				colType:   spansql.Bytes,
 				colLength: 16,
+			},
+			wantType: "[]uint8",
+			wantLen:  16,
+		},
+		{
+			desc: "UUID for BYTES(32)",
+			generator: &UUIDV4Generator{
+				colType:   spansql.Bytes,
+				colLength: 32,
 			},
 			wantType: "[]uint8",
 			wantLen:  16,

--- a/pkg/generator/data/uuid_v4_test.go
+++ b/pkg/generator/data/uuid_v4_test.go
@@ -1,0 +1,123 @@
+// Copyright 2022 Google LLC
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//      http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package data
+
+import (
+	"reflect"
+	"testing"
+
+	"cloud.google.com/go/spanner/spansql"
+)
+
+func TestNewUUIDV4Generator(t *testing.T) {
+	tests := []struct {
+		desc    string
+		colType spansql.TypeBase
+		colLen  int64
+		wantErr bool
+	}{
+		{
+			desc:    "STRING(36) should be valid",
+			colType: spansql.String,
+			colLen:  36,
+			wantErr: false,
+		},
+		{
+			desc:    "STRING(32) should be valid",
+			colType: spansql.String,
+			colLen:  32,
+			wantErr: false,
+		},
+		{
+			desc:    "BYTES(16) should be valid",
+			colType: spansql.Bytes,
+			colLen:  16,
+			wantErr: false,
+		},
+		{
+			desc:    "STRING(16) should be invalid",
+			colType: spansql.String,
+			colLen:  16,
+			wantErr: true,
+		},
+		{
+			desc:    "INT64 should be invalid",
+			colType: spansql.Int64,
+			colLen:  0,
+			wantErr: true,
+		},
+	}
+	for _, test := range tests {
+		t.Run(test.desc, func(t *testing.T) {
+			_, err := NewUUIDV4Generator(test.colType, test.colLen)
+			gotErr := err != nil
+			if gotErr != test.wantErr {
+				t.Errorf("NewUUIDV4Generator(%v, %v) got error = %v, but wantErr = %v", test.colType, test.colLen, err, test.wantErr)
+			}
+		})
+	}
+}
+
+func TestUUIDV4GeneratorNext(t *testing.T) {
+	tests := []struct {
+		desc      string
+		generator *UUIDV4Generator
+		wantType  string
+		wantLen   int
+	}{
+		{
+			desc: "UUID for STRING(36)",
+			generator: &UUIDV4Generator{
+				colType:   spansql.String,
+				colLength: 36,
+			},
+			wantType: "string",
+			wantLen:  36,
+		},
+		{
+			desc: "UUID for STRING(32)",
+			generator: &UUIDV4Generator{
+				colType:   spansql.String,
+				colLength: 32,
+			},
+			wantType: "string",
+			wantLen:  32,
+		},
+		{
+			desc: "UUID for BYTES(16)",
+			generator: &UUIDV4Generator{
+				colType:   spansql.Bytes,
+				colLength: 16,
+			},
+			wantType: "[]uint8",
+			wantLen:  16,
+		},
+	}
+	for _, test := range tests {
+		t.Run(test.desc, func(t *testing.T) {
+			got := test.generator.Next()
+			rv := reflect.ValueOf(got)
+			gotType := rv.Type().String()
+			gotLen := rv.Len()
+
+			if gotType != test.wantType {
+				t.Errorf("%v Next() returns different type: got = %v, want = %v", test.generator, gotType, test.wantType)
+			}
+			if gotLen != test.wantLen {
+				t.Errorf("%v Next() returns different length: got = %v, want = %v", test.generator, gotLen, test.wantLen)
+			}
+		})
+	}
+}


### PR DESCRIPTION
## Overview

This PR has the implementation for UUID v4 support.

The design is written in https://github.com/cloudspannerecosystem/gcsb/issues/1.

## Test result (without config)

Schema:
```
CREATE TABLE t6 (
  id STRING(36) NOT NULL,
  c01 STRING(32) NOT NULL,
  c02 BYTES(16),
  c03 INT64,
) PRIMARY KEY(id)
```

gcsb command:
```
gcsb load -p $PROJECT_ID -i gcsb -d d01 -t t6 -o 5
```

Result:
Note that UUID is automatically populated in `id` column.
```
spanner> select * from t6;
+--------------------------------------+----------------------------------+------------------------+---------------------+
| id                                   | c01                              | c02                    | c03                 |
+--------------------------------------+----------------------------------+------------------------+---------------------+
| 257b2976-2662-457e-95ef-383758bcb362 | iXQtLKJbOebReagfmLEcTDUIDpiFuwRv | ucoAyUe3DldqLJKJoo9RBQ | 7923410221155820266 |
| 29fd6eb2-c89c-42ee-84cf-f1f8227aa673 | JsxFzsPxTUARuIcUljxCwEohglAnQcJd | DELExeADf0zUSl3TuPJvkw | 1297510459945003338 |
| 4b8b15f4-ed71-434e-a1fe-74a4c33a4e5f | QpAaHXHdqGVpnMmffdQMjdyKhDlcmglm | RqgGV6RVGO/0OJlEy8i0EA | 7864384495677479186 |
| 4e8abe20-ee97-4c97-b663-1fda513121bd | JfXGVywdUDZpGfYcSRsSYfZsKqjHpxIh | Wooc+wOZqtEQoM6dUBeo2g | 6597062775239665051 |
| d7f0ab8c-bb05-450f-ab79-90b7780ad043 | rmbMpoNYavnfvAvAesKUJUMfkaNFnvIB | M+wNUnVAz7umOZ4msr7t2g | 4529811403292764668 |
+--------------------------------------+----------------------------------+------------------------+---------------------+
5 rows in set (4.28 msecs)
```

## Test Result (with config)

Schema:
```
CREATE TABLE t6 (
  id STRING(36) NOT NULL,
  c01 STRING(32) NOT NULL,
  c02 BYTES(16),
  c03 INT64,
) PRIMARY KEY(id)
```

Config:
```yaml
tables:
- name: t6
  columns:
  - name: id
    generator:
      type: UUID_V4
  - name: c01
    generator:
      type: UUID_V4
  - name: c02
    generator:
      type: UUID_V4
```

gcsb command:
```
gcsb load -p $PROJECT_ID -i gcsb -d d01 -t t6 -o 5 --config config.yaml
```

Result:
```
spanner> select * from t6;
+--------------------------------------+----------------------------------+------------------------+---------------------+
| id                                   | c01                              | c02                    | c03                 |
+--------------------------------------+----------------------------------+------------------------+---------------------+
| 37fcceac-74a0-4148-bb0f-d3d7c368aba9 | b52808b7cb9b4a7e9a4b549bd389ab4c | GmeTgrUlSRWGujFCApPuMQ | 3407031175830144234 |
| 3ce1bf51-49d9-49d4-a890-cc7962e11722 | 26f79e351b71410fb9d1cc021382cf96 | 9nfD6bBHR5iGS+RNV4lR8g | 1631416344178272893 |
| 5885f3f0-75ce-4ec1-9f24-79f13f949ada | f1f0b88778e0493ba6c23094b4006c13 | NizZ5UH/RZO+en1RUkzm2A | 7778643024011734724 |
| aec21540-70d9-49e1-8bfd-d63a7f4e5dda | 6bab4f29e0a94987a2b430ff486c912b | H5v2fFN4RrWkL3ehWGzuUA | 3821404214491236873 |
| f773c772-b430-4c26-bf6c-a8d7016e1a41 | 308dcb5cb75c48a18e205a49937ff9d6 | 2tZT5+d9QZSOutyDAhwyoQ | 6987019101635680182 |
+--------------------------------------+----------------------------------+------------------------+---------------------+
5 rows in set (2.98 msecs)
```