### PR TITLE
Fix child tables are included when only parent table is specified

### DIFF
--- a/README.md
+++ b/README.md
@@ -99,39 +99,7 @@ tables:
 
 #### Loading into interleaved tables
 
-Loading data into interleaved tables is supported but has some behavioral side effects that should be known. When loading data into an interleaved table, GCSB will detect all tables in the hierarchy and begin loading data at the familial apex. The configured number of operations applies to this apex table. By default, the number of tables for each child table is multiplied by 5. For example:
-
-Using our [test INTERLEAVE schema](schemas/multi_table.sql), we see an INTERLEAVE relationship between the `Singers`, `Albums`, and `Songs` tables.
-
-If we execute a load operation against these tables with total operations set to `10` we will see the following occur
-
-```sh
-gcsb load -t Songs -o 10
-
-+---------+------------+------+-------+---------+
-|  TABLE  | OPERATIONS | READ | WRITE | CONTEXT |
-+---------+------------+------+-------+---------+
-| Singers |         10 | N/A  | N/A   | LOAD    |
-| Albums  |         50 | N/A  | N/A   | LOAD    |
-| Songs   |        250 | N/A  | N/A   | LOAD    |
-+---------+------------+------+-------+---------+
-```
-
-In this case, for each child table we take the number of operations for the parent and multiply it by the default value of `5`.
-
-To change this multiplier, we use the yaml configuration file for the table we want. The `operations.total` value becomes a multiplier. 
-
-```yaml
-tables:
-  - name: Albums
-    operations:
-      total: 10
-  - name: Songs
-    operations:
-      total: 20
-```
-
-At present, GCSB will sort it's operations from the apex down. Meaning it will populate the `Singers` table first and then it's child, and then the next child. Multiple table operations are not mixed within the same transaction. 
+Loading data into interleaved tables is not supported yet. If you want to create splits in the database, you can load data into parent tables.
 
 ### Run
 
@@ -206,6 +174,7 @@ The tool supports the following generator type in the configuration.
 
 ### Not Supported (yet)
 
+- [ ] Interleaved tables for Load and Run phases.
 - [ ] Generating read operations utilizing [ReadByIndex](https://cloud.google.com/spanner/docs/samples/spanner-read-data-with-index#spanner_read_data_with_index-go)
 - [ ] Generating NULL values for load operations. If a column is NULLable, gcsb will still generate a value for it.
 - [ ] JSON column types

--- a/pkg/workload/core_test.go
+++ b/pkg/workload/core_test.go
@@ -1,6 +1,11 @@
 package workload
 
-import "testing"
+import (
+	"testing"
+
+	"github.com/cloudspannerecosystem/gcsb/pkg/config"
+	"github.com/cloudspannerecosystem/gcsb/pkg/schema"
+)
 
 func TestBucketOps(t *testing.T) {
 	tests := []struct {
@@ -38,6 +43,66 @@ func TestBucketOps(t *testing.T) {
 	}
 }
 
+func TestPlan(t *testing.T) {
+	testSchema := schema.NewSchema()
+	t1 := schema.NewTable()
+	t1.SetName("Singers")
+	testSchema.Tables().AddTable(t1)
+
+	t2 := schema.NewTable()
+	t2.SetName("Albums")
+	t2.SetParent(t1)
+	t2.SetParentName(t1.Name())
+	t1.SetChild(t2)
+	t1.SetChildName(t2.Name())
+	testSchema.Tables().AddTable(t2)
+
+	tests := []struct {
+		desc           string
+		initialTargets []string
+		wantTargets    []string
+	}{
+		{
+			desc:           "no tables are planned",
+			initialTargets: []string{},
+			wantTargets:    []string{},
+		},
+		{
+			desc:           "only parent table is planned",
+			initialTargets: []string{"Singers"},
+			wantTargets:    []string{"Singers"},
+		},
+		{
+			desc:           "parent table is also planned",
+			initialTargets: []string{"Albums"},
+			wantTargets:    []string{"Singers", "Albums"},
+		},
+		{
+			desc:           "all tables are planned",
+			initialTargets: []string{"Singers", "Albums"},
+			wantTargets:    []string{"Singers", "Albums"},
+		},
+	}
+	for _, test := range tests {
+		t.Run(test.desc, func(t *testing.T) {
+			workload := CoreWorkload{
+				Schema: testSchema,
+				Config: &config.Config{},
+			}
+
+			err := workload.Plan(JobLoad, test.initialTargets)
+			if err != nil {
+				t.Fatalf("workload.Plan got error: %v", err)
+			}
+
+			got := extractTableNamesFromTargets(workload.plan)
+			if !isSameStringSet(got, test.wantTargets) {
+				t.Errorf("workload.Plan(%v) = %v, but want = %v", test.initialTargets, got, test.wantTargets)
+			}
+		})
+	}
+}
+
 func isSameSlice(a, b []int) bool {
 	if len(a) != len(b) {
 		return false
@@ -48,4 +113,33 @@ func isSameSlice(a, b []int) bool {
 		}
 	}
 	return true
+}
+
+func isSameStringSet(a, b []string) bool {
+	if len(a) != len(b) {
+		return false
+	}
+
+	counters := make(map[string]int)
+	for _, v := range a {
+		counters[v]++
+	}
+	for _, v := range b {
+		counters[v]--
+	}
+
+	for _, counter := range counters {
+		if counter != 0 {
+			return false
+		}
+	}
+	return true
+}
+
+func extractTableNamesFromTargets(targets []*Target) []string {
+	var names []string
+	for _, t := range targets {
+		names = append(names, t.TableName)
+	}
+	return names
 }


### PR DESCRIPTION
Currently even if we specify only a parent table, child tables are included in planning phase.

Example: 
```
$ gcsb load -p ${PROJECT} -i ${INSTANCE} -d ${DATABASE} -t Singers -o 10
2022/03/16 19:45:18 Loading configuration
...
2022/03/16 19:45:26 Executing load phase
2022/03/16 19:45:26 +---------+------------+------+-------+---------+
2022/03/16 19:45:26 |  TABLE  | OPERATIONS | READ | WRITE | CONTEXT |
2022/03/16 19:45:26 +---------+------------+------+-------+---------+
2022/03/16 19:45:26 | Singers |         10 | N/A  | N/A   | LOAD    |
2022/03/16 19:45:26 | Albums  |         50 | N/A  | N/A   | LOAD    |
2022/03/16 19:45:26 | Songs   |        250 | N/A  | N/A   | LOAD    |
2022/03/16 19:45:26 +---------+------------+------+-------+---------+
...
```
Note that even though only `Singers` table is provided, `Albums` and `Songs` tables are included in the generated plan. (`Singers` is the parent table, `Albums` and `Songs` are interleaved child tables.)


This PR fixes this issue and only specified parent table will be executed.

After fix:
```
$ gcsb load -p ${PROJECT} -i ${INSTANCE} -d ${DATABASE} -t Singers -o 10
2022/03/16 19:47:24 Loading configuration
...
2022/03/16 19:47:32 Executing load phase
2022/03/16 19:47:32 +---------+------------+------+-------+---------+
2022/03/16 19:47:32 |  TABLE  | OPERATIONS | READ | WRITE | CONTEXT |
2022/03/16 19:47:32 +---------+------------+------+-------+---------+
2022/03/16 19:47:32 | Singers |         10 | N/A  | N/A   | LOAD    |
2022/03/16 19:47:32 +---------+------------+------+-------+---------+
...
```